### PR TITLE
Append support for compilation as static library

### DIFF
--- a/Sources/ObjC/BAENotificationServiceExtension.m
+++ b/Sources/ObjC/BAENotificationServiceExtension.m
@@ -7,7 +7,11 @@
 
 #import "BAENotificationServiceExtension.h"
 
+#if __has_include(<BatchExtension/BatchExtension-Swift.h>)
 #import <BatchExtension/BatchExtension-Swift.h>
+#else
+#import "BatchExtension-Swift.h"
+#endif
 
 @implementation BAENotificationServiceExtension
 {


### PR DESCRIPTION
A static library requires `#import "BatchExtension-Swift.h"` while framework requires `#import <BatchExtension/BatchExtension-Swift.h>`.

This fix allows to use both.